### PR TITLE
fix: use doubleBackslashes in virtual module path to fix resolve erro…

### DIFF
--- a/common/changes/@modern-js/libuild/main_2023-04-06-06-36.json
+++ b/common/changes/@modern-js/libuild/main_2023-04-06-06-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@modern-js/libuild",
+      "comment": "fix: use doubleBackslashes in virtual module path to fix resolve error in windows",
+      "type": "none"
+    }
+  ],
+  "packageName": "@modern-js/libuild"
+}

--- a/packages/libuild/src/plugins/style/postcssTransformer.ts
+++ b/packages/libuild/src/plugins/style/postcssTransformer.ts
@@ -89,7 +89,11 @@ export const postcssTransformer = async (
   if (Object.values(modules).length) {
     // add hash query for same path, let esbuild cache invalid
     compilation.virtualModule.set(entryPath, code);
-    code = `import "${entryPath}?css_virtual&hash=${getHash(code, 'utf-8')}";export default ${JSON.stringify(modules)}`;
+    const doubleBackslashesPath = entryPath.replace(/\\/g, '\\\\');
+    code = `import "${doubleBackslashesPath}?css_virtual&hash=${getHash(
+      code,
+      'utf-8'
+    )}";export default ${JSON.stringify(modules)}`;
     loader = 'js';
   }
 


### PR DESCRIPTION
…r in windows

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/modern-js-dev/libuild/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Have you run `rush change` for this change?

- [ ] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] Other, please describe:

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**

