### PR TITLE
chore(plugin-swc): bump @modern-js/swc-plugins to v0.3.3

### DIFF
--- a/common/changes/@modern-js/libuild-plugin-swc/swc_plugin_0_5_1_2023-05-29-08-19.json
+++ b/common/changes/@modern-js/libuild-plugin-swc/swc_plugin_0_5_1_2023-05-29-08-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@modern-js/libuild-plugin-swc",
+      "comment": "bump @modern-js/swc-plugins to v0.3.3",
+      "type": "none"
+    }
+  ],
+  "packageName": "@modern-js/libuild-plugin-swc"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -335,12 +335,12 @@ importers:
       '@modern-js/libuild': workspace:*
       '@modern-js/libuild-node-rig': workspace:*
       '@modern-js/libuild-utils': workspace:*
-      '@modern-js/swc-plugins': 0.3.1
+      '@modern-js/swc-plugins': 0.3.3
       chalk: 4.1.0
       eslint: 7.32.0
       typescript: 4.4.4
     dependencies:
-      '@modern-js/swc-plugins': 0.3.1
+      '@modern-js/swc-plugins': 0.3.3
       chalk: 4.1.0
     devDependencies:
       '@modern-js/eslint-config': link:../../tools/eslint-config
@@ -2449,8 +2449,8 @@ packages:
     resolution: {integrity: sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==}
     dev: true
 
-  /@modern-js/swc-plugins-darwin-arm64/0.3.1:
-    resolution: {integrity: sha512-UC4lTWoYnKgubFQ0KwS7OWGK9+gGV0EiiccZK1tLPp4PVEGm/sVi5NfjUueNlOb6KNFT7gxBnJRJnS5lCPMV4A==}
+  /@modern-js/swc-plugins-darwin-arm64/0.3.3:
+    resolution: {integrity: sha512-1yOSwh/5ENHZcy0TuzecrJWMay3YqalqZD/n85T/hyz1kypMi+Q4nm0h5nqRiPvscbMJnHzUPhZ/BK1MsSkoRw==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [darwin]
@@ -2458,8 +2458,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-darwin-x64/0.3.1:
-    resolution: {integrity: sha512-lJOiap9/fdu9eHmHCxsXeZ8vTtUKG9WhBFgU0jdDvebQAO0Tp8WtUzBqF6AeHHKV1w595XqnR01Fq/IArxo5Zw==}
+  /@modern-js/swc-plugins-darwin-x64/0.3.3:
+    resolution: {integrity: sha512-bjQGKNL+Zstlng1nEoifx1K7TjEVlDdCl6WhTNQrOa29JfvHIMMctUJamv25girQ0PC1f49zt9PKTrG6aA1NAw==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [darwin]
@@ -2467,8 +2467,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-gnu/0.3.1:
-    resolution: {integrity: sha512-0k+GpWYxnWzgtoxXf4TRWaRUUEVLsuai+fCP9XCoIcUBgADySfjY7BYnN9ffqnEt5nxyY+TOOZHr6oB2oroFVQ==}
+  /@modern-js/swc-plugins-linux-arm64-gnu/0.3.3:
+    resolution: {integrity: sha512-6f0Afp7gIoNQIWYS+hpu5dB0m+tNGWmj4V/3typniGb5svVaQ5VjeNnK8MLC7IM1l7gYdJlvhgSKRiX1fR5mKQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -2476,8 +2476,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-musl/0.3.1:
-    resolution: {integrity: sha512-VDbwCgtpS5j7c1mXUMsPigdP27uUZFhRAVgPZZPNqcsWArVa4FyMhfGmT96s5UF+YGHNLWrqv1Rq6YOx0/sPzg==}
+  /@modern-js/swc-plugins-linux-arm64-musl/0.3.3:
+    resolution: {integrity: sha512-MHEsvSpdLJWfQ9rvi+ypDgcdhWhn3s0dpNkUBXIjEk4/fNluojWwtR8A9RbGGKN45y4qrmxoEAIfCoXcuOzAYw==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -2485,8 +2485,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-gnu/0.3.1:
-    resolution: {integrity: sha512-xtFKz5xaePvMqSd+h2vpJ6osXsp1nvoR89ropyUI5KBbdrTVqNAvSZhmOyualIlfI5rwAOEv9NWbxXpnZl9gfw==}
+  /@modern-js/swc-plugins-linux-x64-gnu/0.3.3:
+    resolution: {integrity: sha512-NocCWnDeOp5BD+Ix0URwmSIc5VAm1gl/KQzeu2IzFPA9RJsLMtWYmE2UPOtQHuD2hm/iz1N9wZiR3pAkvgKf4w==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -2494,8 +2494,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-musl/0.3.1:
-    resolution: {integrity: sha512-o3T43cksN2sVGgUuepg5SGoR0i+IlPfiyNhNhZeGfr2BXKYo85UvZlKDHvatfnrxfI7YDyWEMOYvIWsSTDXSsg==}
+  /@modern-js/swc-plugins-linux-x64-musl/0.3.3:
+    resolution: {integrity: sha512-GvQjoxH9L65fG3AbhIk7llnMOXTgTNR6xeQVxubSrU1tyMtuApAZOGfZvgH3PcyVgME/38HJJkveA+FqRqeSbQ==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -2503,8 +2503,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-arm64-msvc/0.3.1:
-    resolution: {integrity: sha512-euHVUBnHPOrnLhkONTNO0p2OUgMp/OYuJcNPhfjow7WNh34IuHQqbidF9ROANnFr/JOPJ7rtlDaglJ8ihszDgA==}
+  /@modern-js/swc-plugins-win32-arm64-msvc/0.3.3:
+    resolution: {integrity: sha512-z3a2OVO8Ag2AOSm77WgUd0EN7+McJAdwjhJ3vpfcrhikFqjP0io+k0JrVsvUzJeOsQiDGrLA3oSi6Szb28QLbA==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [win32]
@@ -2512,8 +2512,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-x64-msvc/0.3.1:
-    resolution: {integrity: sha512-i+FQvasCgh4Jr8PP01lk5AYYzu8j4CHonp4rvS+kad6p6vF9FqYVZ10H5391welb0zb+lM2Jm3DWObnlK0EihQ==}
+  /@modern-js/swc-plugins-win32-x64-msvc/0.3.3:
+    resolution: {integrity: sha512-qvAFjFrIn2E14yEcTuw8qTJGNuqHPOWv+nG79XLvQWTIO8EKfr7gvjzLpCR9nry2DBkpc/aOcowmykwAXZd57g==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [win32]
@@ -2521,20 +2521,20 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins/0.3.1:
-    resolution: {integrity: sha512-qytosEUkL+XhQcCJW+7uGcGK6TWvhs4AiolUnYoI1uUeFvfguctbJediDkE1Dthr2GuqHhv9jBgasgZd5kIvHw==}
+  /@modern-js/swc-plugins/0.3.3:
+    resolution: {integrity: sha512-jjw/VAyZv24NQiVdJzZJA89yi7QU62TK5rz+KB0ZZ2BSD57KktQV3QK0c/LUE4D0BvHimH+EPv7v4ykK4mEMbg==}
     engines: {node: '>=14.12'}
     peerDependencies:
-      '@swc/helpers': 0.5.0
+      '@swc/helpers': 0.5.1
     optionalDependencies:
-      '@modern-js/swc-plugins-darwin-arm64': 0.3.1
-      '@modern-js/swc-plugins-darwin-x64': 0.3.1
-      '@modern-js/swc-plugins-linux-arm64-gnu': 0.3.1
-      '@modern-js/swc-plugins-linux-arm64-musl': 0.3.1
-      '@modern-js/swc-plugins-linux-x64-gnu': 0.3.1
-      '@modern-js/swc-plugins-linux-x64-musl': 0.3.1
-      '@modern-js/swc-plugins-win32-arm64-msvc': 0.3.1
-      '@modern-js/swc-plugins-win32-x64-msvc': 0.3.1
+      '@modern-js/swc-plugins-darwin-arm64': 0.3.3
+      '@modern-js/swc-plugins-darwin-x64': 0.3.3
+      '@modern-js/swc-plugins-linux-arm64-gnu': 0.3.3
+      '@modern-js/swc-plugins-linux-arm64-musl': 0.3.3
+      '@modern-js/swc-plugins-linux-x64-gnu': 0.3.3
+      '@modern-js/swc-plugins-linux-x64-musl': 0.3.3
+      '@modern-js/swc-plugins-win32-arm64-msvc': 0.3.3
+      '@modern-js/swc-plugins-win32-x64-msvc': 0.3.3
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:

--- a/packages/libuild-plugin-swc/package.json
+++ b/packages/libuild-plugin-swc/package.json
@@ -25,7 +25,7 @@
     "eslint": "7.32.0"
   },
   "dependencies": {
-    "@modern-js/swc-plugins": "0.3.1",
+    "@modern-js/swc-plugins": "0.3.3",
     "chalk": "4.1.0"
   },
   "files": [

--- a/tests/fixture/src/format/umd/__snapshots__/format.test.ts.snap
+++ b/tests/fixture/src/format/umd/__snapshots__/format.test.ts.snap
@@ -15,7 +15,9 @@ exports[`fixture:format:umd format umd 1`] = `
     });
     Object.defineProperty(exports, \\"a\\", {
         enumerable: true,
-        get: ()=>a
+        get: function() {
+            return a;
+        }
     });
     function a() {
         console.log(1);

--- a/tests/fixture/src/target/__snapshots__/target.test.ts.snap
+++ b/tests/fixture/src/target/__snapshots__/target.test.ts.snap
@@ -31,7 +31,7 @@ function _async_to_generator(fn) {
         });
     };
 }
-var __generator = (void 0) && (void 0).__generator || function(thisArg, body) {
+function _ts_generator(thisArg, body) {
     var f, y, t, g, _ = {
         label: 0,
         sent: function() {
@@ -125,13 +125,13 @@ var __generator = (void 0) && (void 0).__generator || function(thisArg, body) {
             done: true
         };
     }
-};
+}
 function mulAsync(a, b) {
     return _mulAsync.apply(this, arguments);
 }
 function _mulAsync() {
     _mulAsync = _async_to_generator(function(a, b) {
-        return __generator(this, function(_state) {
+        return _ts_generator(this, function(_state) {
             return [
                 2,
                 new Promise(function(resolve, reject) {

--- a/tests/plugins/src/swc/__snapshots__/swc.test.ts.snap
+++ b/tests/plugins/src/swc/__snapshots__/swc.test.ts.snap
@@ -17,7 +17,7 @@ function _define_property(obj, key, value2) {
   }
   return obj;
 }
-var __decorate = function(decorators, target, key, desc) {
+function _ts_decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\")
     r = Reflect.decorate(decorators, target, key, desc);
@@ -26,7 +26,7 @@ var __decorate = function(decorators, target, key, desc) {
       if (d = decorators[i])
         r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
   return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
+}
 function classDecorator(constructor) {
   return class extends constructor {
     constructor(...args) {
@@ -43,7 +43,7 @@ var Greeter = class Greeter2 {
     this.hello = m;
   }
 };
-Greeter = __decorate([
+Greeter = _ts_decorate([
   classDecorator
 ], Greeter);
 var value = /* @__PURE__ */ _jsx(\\"h1\\", {
@@ -73,7 +73,7 @@ function _define_property(obj, key, value2) {
   }
   return obj;
 }
-var __decorate = function(decorators, target, key, desc) {
+function _ts_decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\")
     r = Reflect.decorate(decorators, target, key, desc);
@@ -82,11 +82,11 @@ var __decorate = function(decorators, target, key, desc) {
       if (d = decorators[i])
         r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
   return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = function(k, v) {
+}
+function _ts_metadata(k, v) {
   if (typeof Reflect === \\"object\\" && typeof Reflect.metadata === \\"function\\")
     return Reflect.metadata(k, v);
-};
+}
 function classDecorator(constructor) {
   return class extends constructor {
     constructor(...args) {
@@ -103,10 +103,10 @@ var Greeter = class Greeter2 {
     this.hello = m;
   }
 };
-Greeter = __decorate([
+Greeter = _ts_decorate([
   classDecorator,
-  __metadata(\\"design:type\\", Function),
-  __metadata(\\"design:paramtypes\\", [
+  _ts_metadata(\\"design:type\\", Function),
+  _ts_metadata(\\"design:paramtypes\\", [
     String
   ])
 ], Greeter);
@@ -197,7 +197,7 @@ function _define_property(obj, key, value2) {
   }
   return obj;
 }
-var __decorate = function(decorators, target, key, desc) {
+function _ts_decorate(decorators, target, key, desc) {
   var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
   if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\")
     r = Reflect.decorate(decorators, target, key, desc);
@@ -206,7 +206,7 @@ var __decorate = function(decorators, target, key, desc) {
       if (d = decorators[i])
         r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
   return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
+}
 function classDecorator(constructor) {
   return class extends constructor {
     constructor(...args) {
@@ -223,7 +223,7 @@ var Greeter = class Greeter2 {
     this.hello = m;
   }
 };
-Greeter = __decorate([
+Greeter = _ts_decorate([
   classDecorator
 ], Greeter);
 var value = /* @__PURE__ */ _jsx(\\"h1\\", {

--- a/tests/plugins/src/swc/swc.test.ts
+++ b/tests/plugins/src/swc/swc.test.ts
@@ -52,7 +52,7 @@ describe('fixture:plugin:swc', function () {
     await bundler.build();
 
     const jsOutput = Object.values(bundler.getJSOutput());
-    expect(jsOutput[0].contents.includes('__metadata')).to.be.true;
+    expect(jsOutput[0].contents.includes('_metadata')).to.be.true;
     expect(jsOutput[0].contents).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Detail

Fix the peerDependencies warning of `@swc/plugins` in [modern.js](https://github.com/web-infra-dev/modern.js)

![image](https://github.com/web-infra-dev/libuild/assets/7237365/816113bd-8527-497f-af9e-822db5fbba96)

Diff: https://github.com/web-infra-dev/swc-plugins/compare/release-v0.3.1...release-v0.3.3

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/modern-js-dev/libuild/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [x] Other, please describe:

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
