### PR TITLE
ci: not check changeset when head_ref start with bump and release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,12 +6,6 @@ on:
   pull_request:
     branches:
       - main
-    tags-ignore:
-      - '**'
-    paths-ignore:
-      - LICENSE
-      - '**/*.gitignore'
-      - .editorconfig
 jobs:
   setup-public:
     name: CI

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -1,0 +1,20 @@
+const { promisify } = require('util');
+const { exec: execOrig } = require('child_process');
+
+const exec = promisify(execOrig);
+
+async function main() {
+  console.log('Checking for changeset...');
+  console.log(`GITHUB_HEAD_REF is ${process.argv}`);
+  if (process.argv[2].startsWith('bump') || process.argv[2].startsWith('release')) {
+    return;
+  }
+  const { stdout } = await exec('rush change -v');
+  console.log(stdout);
+}
+
+main().catch((err) => {
+  console.error('Failed to detect doc changes', err);
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+});

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -8,7 +8,7 @@ if [ "$command" = "init" ] ; then
 elif [ "$command" = "install" ] ; then
   npm run install
 elif [ "$command" = "check" ] ; then
-  rush change -v
+  node ./scripts/check.js ${GITHUB_HEAD_REF}
 elif [ "$command" = "build" ] ; then
   npm run build
 elif [ "$command" = "test" ] ; then


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/modern-js-dev/libuild/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Have you run `rush change` for this change?

- [ ] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] Other, please describe:

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
