### PR TITLE
fix(CI): check changeset failed

### DIFF
--- a/scripts/check.js
+++ b/scripts/check.js
@@ -1,14 +1,28 @@
 const { promisify } = require('util');
-const { exec: execOrig } = require('child_process');
+const { exec: execOrig, execSync } = require('child_process');
 
 const exec = promisify(execOrig);
 
+function getCurrentBranch() {
+  return execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+}
+
 async function main() {
   console.log('Checking for changeset...');
-  console.log(`GITHUB_HEAD_REF is ${process.argv}`);
-  if (process.argv[2].startsWith('bump') || process.argv[2].startsWith('release')) {
+
+  const GITHUB_HEAD_REF = process.argv[2];
+
+  if (GITHUB_HEAD_REF) {
+    console.log(`GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}`);
+  }
+
+  const branchName = GITHUB_HEAD_REF || getCurrentBranch();
+
+  if (branchName.startsWith('bump') || branchName.startsWith('release')) {
+    console.log('Skipped in current branch: ', branchName);
     return;
   }
+
   const { stdout } = await exec('rush change -v');
   console.log(stdout);
 }


### PR DESCRIPTION
Fix check changeset failed when GITHUB_HEAD_REF is undefined:

![image](https://github.com/web-infra-dev/libuild/assets/7237365/290dda89-92af-4f2f-b064-1143b246ec50)


https://github.com/web-infra-dev/libuild/actions/runs/5140981075/jobs/9252976583

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/modern-js-dev/libuild/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Have you run `rush change` for this change?

- [ ] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] Other, please describe:

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
