### PR TITLE
fix: remove wrap when determining if rawUrl is a variable

### DIFF
--- a/common/changes/@modern-js/libuild/main_2023-07-27-12-20.json
+++ b/common/changes/@modern-js/libuild/main_2023-07-27-12-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@modern-js/libuild",
+      "comment": "fix: remove wrap when determining if rawUrl is a variable",
+      "type": "none"
+    }
+  ],
+  "packageName": "@modern-js/libuild"
+}


### PR DESCRIPTION
When we add quote in url, we will get a error:
![image](https://github.com/web-infra-dev/libuild/assets/50694858/e3ab5be6-bfa3-4909-b8d3-80658ccda195)
This PR Fix it.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/modern-js-dev/libuild/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Have you run `rush change` for this change?

- [ ] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] Other, please describe:

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
